### PR TITLE
Fix #63 SSL証明書がNginxコンテナで読込不可になる件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG.md
 
+## v1.1.1 - SSL証明書がNginxコンテナで読込不可になる件
+
+- dev-nginxでSSL自己証明書が読み込めないというエラーで、SSL自己証明書の設定を廃止にしました。nginx/conf.d/dev.confのhttps（443）ブロックの削除とcompose.ymlでのマウントを修正。
+
+
 ## アジャイル開発プロセスの振り返りレポート
 
 - 以下のファイルを新規作成

--- a/README.md
+++ b/README.md
@@ -33,12 +33,20 @@ DockerおよびDocker Composeが導入済みならすぐに始められます。
 |Docker|26.1.4以降|
 |Docker Compose|v2.27.1以降|
 
-任意のディレクトリにて、クローンします。
+任意のディレクトリにて、クローンもしくはtar.gzをダウンロードします。
 
 ```bash
 git clone https://github.com/kenno-warise/monitoring-tools.git
 
 cd monitoring-tools
+```
+
+```bash
+curl -L https://github.com/kenno-warise/monitoring-tools/archive/refs/tags/vx.x.x.tar.gz
+
+tar -xvzf monitoring-tools-x.x.x.tar.gz
+
+cd monitoring-tools-x.x.x
 ```
 
 Monitoring-toolsが必要とするディレクトリ構成一覧（それ以外のファイルはCI/CDに必要なファイルなので無視しても大丈夫です）

--- a/compose.yml
+++ b/compose.yml
@@ -90,12 +90,9 @@ services:
     networks:  # カスタムブリッジネットワーク。
       - mynetwork
     volumes:
-      - ./secret/ssl:/etc/ssl
-      - ./secret/.htpasswd:/etc/nginx/.htpasswd
       - ./nginx/conf.d/dev.conf:/etc/nginx/conf.d/dev.conf
     ports:
       - "80:80"
-      - "443:443"
     # 'daemon of'はNginxをフォアグラウンドで実行する（コンテナプロセスが終了しないように）。   
     command: ["sh", "-c", "rm -f /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
     restart: unless-stopped  # 再起動ポリシーでunless-stoppedに設定。手動で停止しない限り再起動する。

--- a/nginx/conf.d/dev.conf
+++ b/nginx/conf.d/dev.conf
@@ -1,9 +1,3 @@
-server {
-    listen       80 default_server;
-    listen  [::]:80 default_server;  # ipv6に対応
-    server_name localhost;
-    return 301 https://$host$request_uri;
-}
 
 # WebSocket の接続を適切に処理するためのヘッダーを設定
 map $http_upgrade $connection_upgrade {
@@ -16,12 +10,9 @@ upstream grafana {
 }
 
 server {
-    listen       443 ssl;
-    listen  [::]:443 ssl;  # ipv6に対応
+    listen       80 default_server;
+    listen  [::]:80 default_server;  # ipv6に対応
     server_name localhost;
-
-    ssl_certificate /etc/ssl/my_certificate.crt;
-    ssl_certificate_key /etc/ssl/my_private.key;
 
     location / {
         proxy_pass http://grafana;
@@ -32,4 +23,39 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }
+
+# server {
+#     listen       80 default_server;
+#     listen  [::]:80 default_server;  # ipv6に対応
+#     server_name localhost;
+#     return 301 https://$host$request_uri;
+# }
+# 
+# # WebSocket の接続を適切に処理するためのヘッダーを設定
+# map $http_upgrade $connection_upgrade {
+#     default upgrade;
+#     '' close;
+# }
+# 
+# upstream grafana {
+#     server grafana:3000;
+# }
+# 
+# server {
+#     listen       443 ssl;
+#     listen  [::]:443 ssl;  # ipv6に対応
+#     server_name localhost;
+# 
+#     ssl_certificate /etc/ssl/my_certificate.crt;
+#     ssl_certificate_key /etc/ssl/my_private.key;
+# 
+#     location / {
+#         proxy_pass http://grafana;
+#         proxy_http_version 1.1;
+#         proxy_set_header Upgrade $http_upgrade;
+#         proxy_set_header Connection $connection_upgrade;
+#         proxy_set_header Host $http_host;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#     }
+# }
 


### PR DESCRIPTION
# 🔄 Pull Request テンプレート

## 📋 概要 / Summary
<!-- 変更の目的や背景、何を実現したかを簡潔に記述 -->

- 認証機能のトークン更新ロジックを改善
- パフォーマンスチューニングの一環でキャッシュ戦略を変更

## 📦 変更内容 / Changes
<!-- 実際にどんな変更をしたかを箇条書きで記述 -->

- `/auth/token.ts` に再試行ロジックを追加
- `.env` に `TOKEN_CACHE_TIMEOUT` を導入
- Grafana通知の閾値を引き下げ

## ✅ チェックリスト / Checklist
- [ ] 動作確認済み（開発環境）
- [ ] テストコード実行済み（`npm test`）
- [ ] 必要なドキュメント変更を行った（README, Wikiなど）
- [ ] CHANGELOG.md に追記済み
- [ ] Issueとの関連付けを行った（例: `Fixes #1234`）

## 🔗 関連Issue・PR / Linked Issues/PRs
<!-- 関連するチケット番号を明記 -->

- Fixes #1234
- Refs #1220, #1211

## 🧠 備考 / Notes
<!-- レビュー担当者に知っておいてほしい事前情報・注意点など -->

- CIジョブが2回連続で失敗するため、再実行をお願いする可能性あり
- Grafana通知設定の反映にはPrometheus再起動が必要

